### PR TITLE
Fix the Hole dimension's biome ID

### DIFF
--- a/src/main/java/mattparks/mods/space/hole/world/gen/BiomeGenBaseHole.java
+++ b/src/main/java/mattparks/mods/space/hole/world/gen/BiomeGenBaseHole.java
@@ -9,7 +9,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 
 public class BiomeGenBaseHole extends BiomeGenBase
 {
-	public static final BiomeGenBase hole = new BiomeGenBaseHole(ConfigManagerVenus.idBiomeVenus).setBiomeName("Hole");
+	public static final BiomeGenBase hole = new BiomeGenBaseHole(ConfigManagerHole.idBiomeHole).setBiomeName("Hole");
 
 	public BiomeGenBaseHole(int var1)
 	{


### PR DESCRIPTION
BiomeGenBaseHole was using Venus' config manager and biome id setting.