### PR TITLE
Fixed Galilean moon bobbing and 3rd person view of moons.

### DIFF
--- a/src/main/java/mattparks/mods/space/callisto/dimension/SkyProviderCallisto.java
+++ b/src/main/java/mattparks/mods/space/callisto/dimension/SkyProviderCallisto.java
@@ -155,45 +155,45 @@ public class SkyProviderCallisto extends IRenderHandler {
 		var23.draw();
 
 		// Render Ganymede
-		var12 = 0.5F;
+		var12 = 10.0F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(0F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderCallisto.ganymedeTexture);
 		var23.startDrawingQuads();
-		var23.addVertexWithUV(-var12, -12.0D, var12, 0, 1);
-		var23.addVertexWithUV(var12, -12.0D, var12, 1, 1);
-		var23.addVertexWithUV(var12, -12.0D, -var12, 1, 0);
-		var23.addVertexWithUV(-var12, -12.0D, -var12, 0, 0);
+		var23.addVertexWithUV(-var12, -240.0D, var12, 0, 1);
+		var23.addVertexWithUV(var12, -240.0D, var12, 1, 1);
+		var23.addVertexWithUV(var12, -240.0D, -var12, 1, 0);
+		var23.addVertexWithUV(-var12, -240.0D, -var12, 0, 0);
 		var23.draw();
 
 		// Render Europa
-		var12 = 0.5F;
+		var12 = 10.0F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(100F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(0F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderCallisto.europaTexture);
 		var23.startDrawingQuads();
-		var23.addVertexWithUV(-var12, -15.0D, var12, 0, 1);
-		var23.addVertexWithUV(var12, -15.0D, var12, 1, 1);
-		var23.addVertexWithUV(var12, -15.0D, -var12, 1, 0);
-		var23.addVertexWithUV(-var12, -15.0D, -var12, 0, 0);
+		var23.addVertexWithUV(-var12, -300.0D, var12, 0, 1);
+		var23.addVertexWithUV(var12, -300.0D, var12, 1, 1);
+		var23.addVertexWithUV(var12, -300.0D, -var12, 1, 0);
+		var23.addVertexWithUV(-var12, -300.0D, -var12, 0, 0);
 		var23.draw();
 
 		// Render IO
-		var12 = 0.5F;
+		var12 = 8.0F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderCallisto.ioTexture);
 		var23.startDrawingQuads();
-		var23.addVertexWithUV(-var12, -25.0D, var12, 0, 1);
-		var23.addVertexWithUV(var12, -25.0D, var12, 1, 1);
-		var23.addVertexWithUV(var12, -25.0D, -var12, 1, 0);
-		var23.addVertexWithUV(-var12, -25.0D, -var12, 0, 0);
+		var23.addVertexWithUV(-var12, -400.0D, var12, 0, 1);
+		var23.addVertexWithUV(var12, -400.0D, var12, 1, 1);
+		var23.addVertexWithUV(var12, -400.0D, -var12, 1, 0);
+		var23.addVertexWithUV(-var12, -400.0D, -var12, 0, 0);
 		var23.draw();
 
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);

--- a/src/main/java/mattparks/mods/space/europa/dimension/SkyProviderEuropa.java
+++ b/src/main/java/mattparks/mods/space/europa/dimension/SkyProviderEuropa.java
@@ -155,45 +155,45 @@ public class SkyProviderEuropa extends IRenderHandler {
 		var23.draw();
 
 		// Render Ganymede
-		var12 = 0.5F;
+		var12 = 11.9F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(0F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderEuropa.ganymedeTexture);
 		var23.startDrawingQuads();
-		var23.addVertexWithUV(-var12, -16.0D, var12, 0, 1);
-		var23.addVertexWithUV(var12, -16.0D, var12, 1, 1);
-		var23.addVertexWithUV(var12, -16.0D, -var12, 1, 0);
-		var23.addVertexWithUV(-var12, -16.0D, -var12, 0, 0);
+		var23.addVertexWithUV(-var12, -381.0D, var12, 0, 1);
+		var23.addVertexWithUV(var12, -381.0D, var12, 1, 1);
+		var23.addVertexWithUV(var12, -381.0D, -var12, 1, 0);
+		var23.addVertexWithUV(-var12, -381.0D, -var12, 0, 0);
 		var23.draw();
 
 		// Render Callisto
-		var12 = 0.5F;
+		var12 = 12.7F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(100F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(0F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderEuropa.callistoTexture);
 		var23.startDrawingQuads();
-		var23.addVertexWithUV(-var12, -15.0D, var12, 0, 1);
-		var23.addVertexWithUV(var12, -15.0D, var12, 1, 1);
-		var23.addVertexWithUV(var12, -15.0D, -var12, 1, 0);
-		var23.addVertexWithUV(-var12, -15.0D, -var12, 0, 0);
+		var23.addVertexWithUV(-var12, -382.0D, var12, 0, 1);
+		var23.addVertexWithUV(var12, -382.0D, var12, 1, 1);
+		var23.addVertexWithUV(var12, -382.0D, -var12, 1, 0);
+		var23.addVertexWithUV(-var12, -382.0D, -var12, 0, 0);
 		var23.draw();
 
 		// Render IO
-		var12 = 0.5F;
+		var12 = 15.8F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderEuropa.ioTexture);
 		var23.startDrawingQuads();
-		var23.addVertexWithUV(-var12, -12.0D, var12, 0, 1);
-		var23.addVertexWithUV(var12, -12.0D, var12, 1, 1);
-		var23.addVertexWithUV(var12, -12.0D, -var12, 1, 0);
-		var23.addVertexWithUV(-var12, -12.0D, -var12, 0, 0);
+		var23.addVertexWithUV(-var12, -379.0D, var12, 0, 1);
+		var23.addVertexWithUV(var12, -379.0D, var12, 1, 1);
+		var23.addVertexWithUV(var12, -379.0D, -var12, 1, 0);
+		var23.addVertexWithUV(-var12, -379.0D, -var12, 0, 0);
 		var23.draw();
 
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);

--- a/src/main/java/mattparks/mods/space/io/dimension/SkyProviderIo.java
+++ b/src/main/java/mattparks/mods/space/io/dimension/SkyProviderIo.java
@@ -221,45 +221,45 @@ public class SkyProviderIo extends IRenderHandler {
 		tessellator1.draw();
 
 		// Render Ganymede
-		f10 = 0.5F;
+		f10 = 10.0F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(0F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderIo.ganymedeTexture);
 		tessellator1.startDrawingQuads();
-		tessellator1.addVertexWithUV(-f10, -27.0D, f10, 0, 1);
-		tessellator1.addVertexWithUV(f10, -27.0D, f10, 1, 1);
-		tessellator1.addVertexWithUV(f10, -27.0D, -f10, 1, 0);
-		tessellator1.addVertexWithUV(-f10, -27.0D, -f10, 0, 0);
+		tessellator1.addVertexWithUV(-f10, -540.0D, f10, 0, 1);
+		tessellator1.addVertexWithUV(f10, -540.0D, f10, 1, 1);
+		tessellator1.addVertexWithUV(f10, -540.0D, -f10, 1, 0);
+		tessellator1.addVertexWithUV(-f10, -540.0D, -f10, 0, 0);
 		tessellator1.draw();
 
 		// Render Europa
-		f10 = 0.5F;
+		f10 = 10.0F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(100F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(0F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderIo.europaTexture);
 		tessellator1.startDrawingQuads();
-		tessellator1.addVertexWithUV(-f10, -15.0D, f10, 0, 1);
-		tessellator1.addVertexWithUV(f10, -15.0D, f10, 1, 1);
-		tessellator1.addVertexWithUV(f10, -15.0D, -f10, 1, 0);
-		tessellator1.addVertexWithUV(-f10, -15.0D, -f10, 0, 0);
+		tessellator1.addVertexWithUV(-f10, -300.0D, f10, 0, 1);
+		tessellator1.addVertexWithUV(f10, -300.0D, f10, 1, 1);
+		tessellator1.addVertexWithUV(f10, -300.0D, -f10, 1, 0);
+		tessellator1.addVertexWithUV(-f10, -300.0D, -f10, 0, 0);
 		tessellator1.draw();
 
 		// Render Callisto
-		f10 = 0.5F;
+		f10 = 10.0F;
 		GL11.glScalef(0.6F, 0.6F, 0.6F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 1.0F);
 		GL11.glRotatef(300F, 1.0F, 0.0F, 0.0F);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1F);
 		FMLClientHandler.instance().getClient().renderEngine.bindTexture(SkyProviderIo.callistoTexture);
 		tessellator1.startDrawingQuads();
-		tessellator1.addVertexWithUV(-f10, -25.0D, f10, 0, 1);
-		tessellator1.addVertexWithUV(f10, -25.0D, f10, 1, 1);
-		tessellator1.addVertexWithUV(f10, -25.0D, -f10, 1, 0);
-		tessellator1.addVertexWithUV(-f10, -25.0D, -f10, 0, 0);
+		tessellator1.addVertexWithUV(-f10, -500.0D, f10, 0, 1);
+		tessellator1.addVertexWithUV(f10, -500.0D, f10, 1, 1);
+		tessellator1.addVertexWithUV(f10, -500.0D, -f10, 1, 0);
+		tessellator1.addVertexWithUV(-f10, -500.0D, -f10, 0, 0);
 		tessellator1.draw();
 
 		GL11.glDisable(GL11.GL_TEXTURE_2D);


### PR DESCRIPTION
I moved the rendering of all the Galilean moons backwards on the z axis (while keeping their apparent size the same) so that they aren't affected as much by view bobbing. It also fixes 3rd person view showing that the moons are "orbiting" close to the player's head. These problems are show here: http://gfycat.com/DisfiguredOpenJanenschia.
